### PR TITLE
Fix for issue #10

### DIFF
--- a/wscript
+++ b/wscript
@@ -188,7 +188,7 @@ def configure(conf):
 		subprocess.check_output(["git", "rev-parse", "--verify", "--short", "HEAD"])
 			.decode().strip())
 
-	conf.write_config_header("config-autogen.h")
+	conf.write_config_header("config-autogen.h", remove=False)
 
 def build(bld):
 	bld.recurse("src")


### PR DESCRIPTION
Explicitly keep defines in the build environment. This preserves HAVE_WORKING_POLL and fixes Linux build issue #10.
