### PR TITLE
Updated for compatibility with stdlib 2.19

### DIFF
--- a/src/serialosc.c
+++ b/src/serialosc.c
@@ -14,7 +14,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#define _BSD_SOURCE
+#define _DEFAULT_SOURCE
 
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
After libc 2.19, feature test macro _DEFAULT_SOURCE replaced _SVID_SOURCE and _BSD_SOURCE. This tiny fix should fix ./waf on Ubuntu 14.04 and other updated distros.