### PR TITLE
Add -v argument to show version to serialoscd

### DIFF
--- a/src/serialosc-device/main.c
+++ b/src/serialosc-device/main.c
@@ -25,12 +25,6 @@
 
 #include <serialosc/serialosc.h>
 
-static void
-print_version(void)
-{
-	printf("serialosc %s (%s)\n", VERSION, GIT_COMMIT);
-}
-
 int
 main(int argc, char **argv)
 {
@@ -38,14 +32,6 @@ main(int argc, char **argv)
 
 	if (argc < 2)
 		return EXIT_FAILURE;
-
-	if (argv[1][0] == '-') {
-		switch (argv[1][1]) {
-		case 'v':
-			print_version();
-			return EXIT_SUCCESS;
-		}
-	}
 
 	argv[0][strlen(argv[0]) - 1] = ' ';
 

--- a/src/serialoscd/uv.c
+++ b/src/serialoscd/uv.c
@@ -725,6 +725,12 @@ free_paths(struct sosc_supervisor *self)
 	s_free(self->device_exe_path);
 }
 
+static void
+print_version(void)
+{
+	printf("serialoscd %s (%s)\n", VERSION, GIT_COMMIT);
+}
+
 int
 #ifdef _WIN32
 supervisor_main(int argc, char **argv)
@@ -732,6 +738,16 @@ supervisor_main(int argc, char **argv)
 main(int argc, char **argv)
 #endif
 {
+	if (argc == 2) {
+		if (argv[1][0] == '-') {
+			switch (argv[1][1]) {
+			case 'v':
+				print_version();
+				return EXIT_SUCCESS;
+			}
+		}
+	}
+
 	struct sosc_supervisor self = {NULL};
 
 	uv_setup_args(argc, argv);


### PR DESCRIPTION
Please check this very well, I have pretty much no C knowledge :x
Tested on Linux, working as expected. No arguments still runs the applications, passing `-v` shows the version.

Just noticed that for serialosc-detecter there are totally separate files for linux, macos and windows. Shall I add the same code to the macos and windows files as well?

Fixes #26 