### PR TITLE
Allow using system installed libuv

### DIFF
--- a/third-party/wscript
+++ b/third-party/wscript
@@ -51,7 +51,8 @@ def build_uv(ctx):
 		name='LIBUV')
 
 def build(ctx):
-	build_uv(ctx)
+	if not ctx.env.SOSC_SYSTEM_LIBUV:
+		build_uv(ctx)
 	ctx.recurse('confuse')
 
 # vim: set ts=4 sts=4 noet :

--- a/wscript
+++ b/wscript
@@ -80,6 +80,17 @@ def check_libmonome(conf):
 
 		msg="Checking for libmonome")
 
+def check_libuv(conf):
+	conf.check_cc(
+		define_name="HAVE_LIBUV",
+		mandatory=True,
+		quote=0,
+
+		lib="uv",
+		uselib_store="LIBUV",
+
+		msg="Checking for libuv")
+
 def check_strfuncs(ctx):
 	check = lambda func_name: ctx.check_cc(
 			define_name='HAVE_{}'.format(func_name.upper()),
@@ -150,13 +161,13 @@ def options(opt):
 			default=False, help="on Darwin, build serialosc as a combination 32 and 64 bit executable [disabled by default]")
 	sosc_opts.add_option("--disable-zeroconf", action="store_true",
 			default=False, help="disable all zeroconf code, including runtime loading of the DNSSD library.")
+	sosc_opts.add_option("--enable-system-libuv", action="store_true",
+			default=False, help="use libuv provided by the system instead of the included git submodule.")
 
 def configure(conf):
 	# just for output prettifying
 	# print() (as a function) ddoesn't work on python <2.7
 	separator = lambda: sys.stdout.write("\n")
-
-	check_submodules(conf)
 
 	if conf.options.host:
 		override_find_program(conf.options.host)
@@ -191,6 +202,12 @@ def configure(conf):
 
 	check_libmonome(conf)
 	check_liblo(conf)
+
+	conf.env.SOSC_SYSTEM_LIBUV = conf.options.enable_system_libuv
+	if conf.options.enable_system_libuv:
+		check_libuv(conf)
+	else:
+		check_submodules(conf)
 
 	# stuff for libconfuse
 	check_strfuncs(conf)


### PR DESCRIPTION
Instead of the included git submodule.
Can be enabled using the configure flag `--enable-system-libuv`

This fixes #30 

@wrl I went for an explicit configure option instead of "magic" based on if the submodule would or wouldn't exist. IMHO this is a bit cleaner plus it allows the build to fail when the packager wants to use the system libuv and it isn't installed (and the git submodule is checked out).

Also, I didn't make the flag Linux specific since libuv can be installed systemwide on both macOS (http://formulae.brew.sh/formula/libuv) and Windows (https://www.nuget.org/packages/Libuv/).