### PR TITLE
check the right ipc_msg length variable

### DIFF
--- a/src/serialoscd/uv.c
+++ b/src/serialoscd/uv.c
@@ -164,7 +164,7 @@ dispatch_ipc_msgs(uv_stream_t *stream, ssize_t nbytes, const uv_buf_t *buf,
 	while (nbytes > 0) {
 		msg_nbytes = sosc_ipc_msg_from_buf(buf_cursor, nbytes, &msg);
 
-		if (nbytes < 0) {
+		if (msg_nbytes < 0) {
 			fprintf(stderr, " [-] bad message, bailing out\n");
 			return;
 		}


### PR DESCRIPTION
hey @wrl, i think this check was supposed to be `msg_nbytes < 0`. this fixes the segfault described in #22, because we no longer pass null messages to `handle_device_msg`.

the problem is that i'm getting a lot of "bad message, bailing out" errors now when replugging the grid, any tips on how to attack those?