### PR TITLE
command-line option for grid state directory

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "third-party/libuv"]
 	path = third-party/libuv
 	url = https://github.com/libuv/libuv.git
+[submodule "third-party/optparse"]
+	path = third-party/optparse
+	url = https://github.com/skeeto/optparse

--- a/include/serialosc/platform.h
+++ b/include/serialosc/platform.h
@@ -16,7 +16,7 @@
 
 #pragma once
 
-char *sosc_get_config_directory(void);
+char *sosc_get_default_config_dir(void);
 
 char *s_asprintf(const char *fmt, ...);
 void *s_malloc(size_t size);

--- a/include/serialosc/serialosc.h
+++ b/include/serialosc/serialosc.h
@@ -72,11 +72,11 @@ typedef struct sosc_state {
 } sosc_state_t;
 
 int  sosc_event_loop(struct sosc_state *state);
-void sosc_server_run(monome_t *monome);
+void sosc_server_run(const char *config_dir, monome_t *monome);
 
 int sosc_config_create_directory();
-int sosc_config_read(const char *serial, sosc_config_t *config);
-int sosc_config_write(const char *serial, sosc_state_t *state);
+int sosc_config_read(const char *config_dir, const char *serial, sosc_config_t *config);
+int sosc_config_write(const char *config_dir, const char *serial, sosc_state_t *state);
 
 void sosc_port_itos(char *dest, long int port);
 size_t sosc_strlcpy(char *dst, const char *src, size_t size);

--- a/src/common/platform/darwin.c
+++ b/src/common/platform/darwin.c
@@ -20,7 +20,7 @@
 #include <serialosc/platform.h>
 
 char *
-sosc_get_config_directory(void)
+sosc_get_default_config_dir(void)
 {
 	return s_asprintf("%s/Library/Preferences/org.monome.serialosc",
 					  getenv("HOME"));
@@ -32,7 +32,7 @@ sosc_config_create_directory(void)
 	struct stat buf[1];
 	char *cdir;
 
-	cdir = sosc_get_config_directory();
+	cdir = sosc_get_default_config_dir();
 
 	if (stat(cdir, buf) && mkdir(cdir, S_IRWXU))
 		goto err_mkdir;

--- a/src/common/platform/linux.c
+++ b/src/common/platform/linux.c
@@ -20,7 +20,7 @@
 #include <serialosc/platform.h>
 
 char *
-sosc_get_config_directory(void)
+sosc_get_default_config_dir(void)
 {
 	char *dir;
 
@@ -38,7 +38,7 @@ sosc_config_create_directory(void)
 	char *cdir, *xdgdir;
 	struct stat buf[1];
 
-	cdir = sosc_get_config_directory();
+	cdir = sosc_get_default_config_dir();
 
 	if (stat(cdir, buf)) {
 		if (!getenv("XDG_CONFIG_HOME")) {

--- a/src/common/platform/windows.c
+++ b/src/common/platform/windows.c
@@ -45,7 +45,7 @@ mk_monome_dir(char *cdir)
 }
 
 char *
-sosc_get_config_directory(void)
+sosc_get_default_config_dir(void)
 {
 	char *appdata;
 
@@ -61,7 +61,7 @@ sosc_config_create_directory(void)
 	char *cdir;
 	struct _stat buf[1];
 
-	cdir = sosc_get_config_directory();
+	cdir = sosc_get_default_config_dir();
 	if (_stat(cdir, buf)) {
 		if (mk_monome_dir(cdir))
 			goto err_mkdir;

--- a/src/serialosc-device/config.c
+++ b/src/serialosc-device/config.c
@@ -69,19 +69,13 @@ prepend_slash_if_necessary(char **dest, char *prefix)
 }
 
 static char *
-path_for_serial(const char *serial)
+path_for_serial(const char *config_dir, const char *serial)
 {
-	char *path, *cdir;
-
-	cdir = sosc_get_default_config_dir();
-	path = s_asprintf("%s/%s.conf", cdir, serial);
-
-	s_free(cdir);
-	return path;
+	return s_asprintf("%s/%s.conf", config_dir, serial);
 }
 
 int
-sosc_config_read(const char *serial, sosc_config_t *config)
+sosc_config_read(const char *config_dir, const char *serial, sosc_config_t *config)
 {
 	cfg_t *cfg, *sec;
 	char *path;
@@ -90,7 +84,12 @@ sosc_config_read(const char *serial, sosc_config_t *config)
 		return 1;
 
 	cfg = cfg_init(opts, CFGF_NOCASE);
-	path = path_for_serial(serial);
+
+	if (config_dir != NULL) {
+		path = path_for_serial(config_dir, serial);
+	} else {
+		path = path_for_serial(sosc_get_default_config_dir(), serial);
+	}
 
 	switch( cfg_parse(cfg, path) ) {
 	case CFG_PARSE_ERROR:
@@ -118,7 +117,7 @@ sosc_config_read(const char *serial, sosc_config_t *config)
 }
 
 int
-sosc_config_write(const char *serial, sosc_state_t *state)
+sosc_config_write(const char *config_dir, const char *serial, sosc_state_t *state)
 {
 	cfg_t *cfg, *sec;
 	char *path;
@@ -130,7 +129,12 @@ sosc_config_write(const char *serial, sosc_state_t *state)
 
 	cfg = cfg_init(opts, CFGF_NOCASE);
 
-	path = path_for_serial(serial);
+	if (config_dir != NULL) {
+		path = path_for_serial(config_dir, serial);
+	} else {
+		path = path_for_serial(sosc_get_default_config_dir(), serial);
+	}
+
 	if (!(f = fopen(path, "w"))) {
 		s_free(path);
 		return 1;

--- a/src/serialosc-device/config.c
+++ b/src/serialosc-device/config.c
@@ -73,7 +73,7 @@ path_for_serial(const char *serial)
 {
 	char *path, *cdir;
 
-	cdir = sosc_get_config_directory();
+	cdir = sosc_get_default_config_dir();
 	path = s_asprintf("%s/%s.conf", cdir, serial);
 
 	s_free(cdir);

--- a/src/serialosc-device/main.c
+++ b/src/serialosc-device/main.c
@@ -22,6 +22,9 @@
 
 #include <uv.h>
 #include <monome.h>
+#define OPTPARSE_IMPLEMENTATION
+#define OPTPARSE_API static
+#include <optparse/optparse.h>
 
 #include <serialosc/serialosc.h>
 
@@ -29,21 +32,50 @@ int
 main(int argc, char **argv)
 {
 	monome_t *device;
+	const char *config_dir = NULL;
+	const char *device_arg;
 
-	if (argc < 2)
+	int opt, longindex;
+	struct optparse options;
+	struct optparse_long longopts[] = {
+		{"config-dir", 'c', OPTPARSE_REQUIRED},
+		{0, 0, 0}
+	};
+
+	uv_setup_args(argc, argv);
+	optparse_init(&options, argv);
+
+	while ((opt = optparse_long(&options, longopts, &longindex)) != -1) {
+		switch (opt) {
+		case 'c':
+			config_dir = options.optarg;
+			break;
+		default:
+			fprintf(stderr, "%s: %s\n", argv[0], options.errmsg);
+			return EXIT_FAILURE;
+		}
+	}
+
+	if (options.optind < argc) {
+		device_arg = optparse_arg(&options);
+	} else {
+		fprintf(stderr, "%s: device not specified, exiting\n", argv[0]);
 		return EXIT_FAILURE;
+	}
+
+	if (!(device = monome_open(device_arg))) {
+		fprintf(stderr, "%s: failed to open device %s\n", argv[0], device_arg);
+		return EXIT_FAILURE;
+	}
 
 	argv[0][strlen(argv[0]) - 1] = ' ';
-
-	if (!(device = monome_open(argv[1])))
-		return EXIT_FAILURE;
 
 #ifndef WIN32
 	setenv("AVAHI_COMPAT_NOWARN", "shut up", 1);
 #endif
 
 	sosc_zeroconf_init();
-	sosc_server_run(device);
+	sosc_server_run(config_dir, device);
 	monome_close(device);
 
 	return EXIT_SUCCESS;

--- a/src/serialosc-device/server.c
+++ b/src/serialosc-device/server.c
@@ -214,7 +214,7 @@ send_osc_port_change(int fd, uint16_t port)
 #endif
 
 void
-sosc_server_run(monome_t *monome)
+sosc_server_run(const char *config_dir, monome_t *monome)
 {
 	char *svc_name;
 	sosc_state_t state = {
@@ -224,7 +224,7 @@ sosc_server_run(monome_t *monome)
 		.ipc_out_fd = (!isatty(STDOUT_FILENO)) ? STDOUT_FILENO : -1
 	};
 
-	if (sosc_config_read(monome_get_serial(state.monome), &state.config)) {
+	if (sosc_config_read(config_dir, monome_get_serial(state.monome), &state.config)) {
 		fprintf(
 			stderr, "serialosc [%s]: couldn't read config, using defaults\n",
 			monome_get_serial(state.monome));
@@ -294,7 +294,7 @@ sosc_server_run(monome_t *monome)
 	} else
 		send_simple_ipc(state.ipc_out_fd, SOSC_DEVICE_DISCONNECTION);
 
-	if (sosc_config_write(monome_get_serial(state.monome), &state)) {
+	if (sosc_config_write(config_dir, monome_get_serial(state.monome), &state)) {
 		fprintf(
 			stderr, "serialosc [%s]: couldn't write config :(\n",
 			monome_get_serial(state.monome));


### PR DESCRIPTION
this adds support for `--config-dir` & `-c` option for both the device server and the supervisor as requested in #36.

command-line argument parsing is done by a added submodule -- optparse (header-only getopt-like argument parsing library). the `config-dir` parameter is then forwarded down to `sosc_config_read` and `sosc_config_write`.