### PR TITLE
fix address-of-packed-member compiler warnings (fixes #28)

### DIFF
--- a/include/serialosc/ipc.h
+++ b/include/serialosc/ipc.h
@@ -18,14 +18,12 @@
 
 #include <stdint.h>
 
-#ifndef PACKED
-#define PACKED __attribute__((__packed__))
-#endif
-
 #ifdef WIN32
 #define SOSC_PIPE_PREFIX "\\\\.\\pipe\\org.monome.serialosc-"
 #define SOSC_DETECTOR_PIPE (SOSC_PIPE_PREFIX "detector")
 #endif
+
+#define SOSC_IPC_MSG_BUFFER_SIZE 256
 
 typedef enum {
 	/* device -> supervisor */
@@ -45,20 +43,20 @@ typedef struct sosc_ipc_msg {
 	__extension__ union {
 		struct {
 			char *devnode;
-		} PACKED connection;
+		} connection;
 
 		struct {
 			char *serial;
 			char *friendly;
-		} PACKED device_info;
+		} device_info;
 
 		struct {
 			uint16_t port;
-		} PACKED port_change;
+		} port_change;
 	};
 
 	uint16_t magic;
-} PACKED sosc_ipc_msg_t;
+} sosc_ipc_msg_t;
 
 int sosc_ipc_msg_write(int fd, sosc_ipc_msg_t *msg);
 int sosc_ipc_msg_read(int fd, sosc_ipc_msg_t *buf);

--- a/src/common/ipc.c
+++ b/src/common/ipc.c
@@ -75,7 +75,7 @@ read_strdata(int fd, size_t n, ...)
 int
 sosc_ipc_msg_write(int fd, sosc_ipc_msg_t *msg)
 {
-	uint8_t buf[64];
+	uint8_t buf[SOSC_IPC_MSG_BUFFER_SIZE];
 	ssize_t written;
 	ssize_t bufsiz;
 

--- a/src/serialosc-detector/windows.c
+++ b/src/serialosc-detector/windows.c
@@ -42,7 +42,7 @@ struct detector_state {
 static void
 send_connect(const struct detector_state *state, char *port)
 {
-	uint8_t buf[64];
+	uint8_t buf[SOSC_IPC_MSG_BUFFER_SIZE];
 	DWORD written;
 	size_t bufsiz;
 

--- a/src/serialosc-device/server.c
+++ b/src/serialosc-device/server.c
@@ -163,7 +163,7 @@ static void
 send_ipc_msg(sosc_ipc_msg_t *msg)
 {
 	HANDLE p = (HANDLE) _get_osfhandle(STDOUT_FILENO);
-	uint8_t buf[64];
+	uint8_t buf[SOSC_IPC_MSG_BUFFER_SIZE];
 	DWORD written;
 	ssize_t bufsiz;
 

--- a/src/serialoscd/uv.c
+++ b/src/serialoscd/uv.c
@@ -246,7 +246,7 @@ write_ipc_msg_to_stream(uv_stream_t *stream, struct sosc_ipc_msg *msg)
 {
 	uv_buf_t uv_buf;
 	uv_write_t *req;
-	uint8_t buf[64];
+	uint8_t buf[SOSC_IPC_MSG_BUFFER_SIZE];
 	ssize_t nbytes;
 
 	nbytes = sosc_ipc_msg_to_buf(buf, sizeof(buf), msg);


### PR DESCRIPTION
This fixes compiler warnings with clang (#28). Buffer size for IPC messages is also increased so the new structures actually fit into the allocated buffers. Also fixes a problem with the arc described in the linked [lines post](https://llllllll.co/t/building-serialosc-on-arch-linux/738/12).