### PR TITLE
Don't require git to build serialosc

### DIFF
--- a/wscript
+++ b/wscript
@@ -266,7 +266,7 @@ def configure(conf):
 		conf.env.GIT_COMMIT = subprocess.check_output(
 			["git", "rev-parse", "--verify", "--short", "HEAD"],
 			stderr=devnull).decode().strip()
-	except subprocess.CalledProcessError:
+	except (subprocess.CalledProcessError, OSError):
 		conf.env.GIT_COMMIT = ''
 
 	conf.define("VERSION", VERSION)


### PR DESCRIPTION
This is something I ran into while doing RPM packaging for serialosc (which you can see [here](https://copr.fedorainfracloud.org/coprs/eklitzke/monome/)). If `git` is missing in the build environment the waf script will fail with an uncaught exception which prevents the `waf configure` command from terminating successfully.