### PR TITLE
include stdarg for reliable compilation on posix

### DIFF
--- a/src/common/platform/posix.c
+++ b/src/common/platform/posix.c
@@ -17,6 +17,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+#include <stdarg.h>
 
 #include <serialosc/serialosc.h>
 


### PR DESCRIPTION
tiny change to explicitly include `stdarg.h` from `posix.c`, which requires it