### PR TITLE
Adding suport for the neotrellis grid devtype in linux detector

### DIFF
--- a/src/serialosc-detector/libudev.c
+++ b/src/serialosc-detector/libudev.c
@@ -54,7 +54,9 @@ send_connect(const char *devnode)
 static int
 has_usb_serial_parent(struct udev_device *ud)
 {
-	if (udev_device_get_parent_with_subsystem_devtype(ud, "usb", NULL))
+	if (udev_device_get_parent_with_subsystem_devtype(ud, "usb_serial", NULL))
+		return 1;
+	else if (udev_device_get_parent_with_subsystem_devtype(ud, "usb", NULL))
 		return 1;
 	else
 		return 0;

--- a/src/serialosc-detector/libudev.c
+++ b/src/serialosc-detector/libudev.c
@@ -54,7 +54,7 @@ send_connect(const char *devnode)
 static int
 has_usb_serial_parent(struct udev_device *ud)
 {
-	if (udev_device_get_parent_with_subsystem_devtype(ud, "usb_serial", NULL))
+	if (udev_device_get_parent_with_subsystem_devtype(ud, "usb-serial", NULL))
 		return 1;
 	else if (udev_device_get_parent_with_subsystem_devtype(ud, "usb", NULL))
 		return 1;

--- a/src/serialosc-detector/libudev.c
+++ b/src/serialosc-detector/libudev.c
@@ -54,7 +54,7 @@ send_connect(const char *devnode)
 static int
 has_usb_serial_parent(struct udev_device *ud)
 {
-	if (udev_device_get_parent_with_subsystem_devtype(ud, "usb-serial", NULL))
+	if (udev_device_get_parent_with_subsystem_devtype(ud, "usb", NULL))
 		return 1;
 	else
 		return 0;


### PR DESCRIPTION
This is untested as i don't own an original grid, but it should work nonetheless, as it's the same as before but adding support for the neotrellis grid devtype