### PR TITLE
RFC: Package as Portable Service for Linux

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "third-party/optparse"]
 	path = third-party/optparse
 	url = https://github.com/skeeto/optparse
+[submodule "libmonome"]
+	path = libmonome
+	url = https://github.com/monome/libmonome

--- a/README.md
+++ b/README.md
@@ -17,4 +17,23 @@ see [releases](https://github.com/monome/serialosc/releases) for mac and windows
 ./waf
 sudo ./waf install
 ```
+## portable service for Linux
 
+Some Linux systems can install serialosc as a [systemd portable service](https://systemd.io/PORTABLE_SERVICES/).
+
+Instructions to set this up:
+
+ 1. install [mkosi](https://github.com/systemd/mkosi/) build tool.
+ 2. build and install disk image:
+
+      sudo mkosi -t directory -o /opt/serialosc/
+
+ 3. attach to system, enable and start service:
+
+      sudo portablectl attach --enable --now /opt/serialosc --profile trusted
+
+To disable the service again, you can run `sudo portablectl detach --now /opt/serialosc`.
+
+Note that because `mkosi` runs as root, you may hit issues with the 'safe directories' feature
+of Git version >= 2.35. If needed, you can disable this safety feature by running `sudo git config
+--global --add safe.directory '*'`.

--- a/data/serialosc.service
+++ b/data/serialosc.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=osc server for monome devices
+
+[Service]
+ExecStart=/usr/bin/serialoscd
+
+[Install]
+WantedBy=multi-user.target

--- a/mkosi.build
+++ b/mkosi.build
@@ -1,0 +1,22 @@
+set -e
+
+export PREFIX=/usr
+
+cd libmonome
+./waf configure --prefix=${PREFIX}
+./waf install
+
+cd ..
+env LDFLAGS=-L${DESTDIR}/${PREFIX}/lib64 CFLAGS=-I${DESTDIR}/${PREFIX}/include ./waf configure --prefix=${PREFIX} --disable-zeroconf
+./waf install
+
+mkdir -p ${DESTDIR}/${PREFIX}/lib/systemd/system/
+cp data/serialosc.service ${DESTDIR}/${PREFIX}/lib/systemd/system/
+
+mkdir -p "$DESTDIR"/etc
+cp /usr/lib/os-release "$DESTDIR"/etc/os-release
+cat >> "$DESTDIR"/etc/os-release <<EOF
+PORTABLE_PRETTY_NAME="serialosc portable service"
+EOF
+
+touch "$DESTDIR"/etc/resolv.conf

--- a/mkosi.default
+++ b/mkosi.default
@@ -1,0 +1,15 @@
+[Distribution]
+Distribution=fedora
+Release=35
+
+[Packages]
+BuildPackages=
+    gcc
+    git
+    liblo-devel
+    python-unversioned-command
+    python3
+    systemd-devel
+
+Packages=
+    liblo

--- a/third-party/wscript
+++ b/third-party/wscript
@@ -32,6 +32,10 @@ def build_uv(ctx):
 				for x in from_gyp['libraries']]
 	elif ctx.env.DEST_OS == 'darwin':
 		from_gyp['ldflags'].remove('-pthread')
+	if ctx.env.DEST_OS == 'linux':
+		extra_cflags += [
+			'-Wno-sign-compare'
+		]
 
 	ctx.env.append_unique('LINKFLAGS_UV_FLAGS', from_gyp['ldflags'])
 	ctx.env.append_unique('LIB_UV_FLAGS', from_gyp['libraries'])


### PR DESCRIPTION
Hello,
This is an experiment, feel free to close if you don't want an open PR hanging around.

The goal here is to provide simpler deployment workflow on Linux, by using a new systemd feature that allows distributing system services as containers.

I am testing this out on Fedora 35 and it's working nicely, in a few years it may be a solid way to distribute binaries of serialosc for Linux :)

See README for use instructions.