### PR TITLE
Set min. macOS deploy target to 10.13 for fmemopen

### DIFF
--- a/wscript
+++ b/wscript
@@ -272,8 +272,8 @@ def configure(conf):
 					'-Wl,--enable-stdcall-fixup'])
 		conf.env.append_unique("WINRCFLAGS", ["-O", "coff"])
 	elif conf.env.DEST_OS == "darwin":
-		conf.env.append_unique("CFLAGS", ["-mmacosx-version-min=10.5"])
-		conf.env.append_unique("LINKFLAGS", ["-mmacosx-version-min=10.5"])
+		conf.env.append_unique("CFLAGS", ["-mmacosx-version-min=10.13"])
+		conf.env.append_unique("LINKFLAGS", ["-mmacosx-version-min=10.13"])
 
 	if conf.options.disable_zeroconf:
 		conf.define("SOSC_NO_ZEROCONF", True)


### PR DESCRIPTION
When updating [serialosc in homebrew](https://github.com/Homebrew/homebrew-core/pull/159939), I realized that it didn't seem to [build on Darwin](https://github.com/Homebrew/homebrew-core/actions/runs/7522449788/job/20474502425?pr=159939) since (?) the addition of `fmemopen`, since this API was only added in OS X 10.13:

```
==> python3 ./waf build
  Waf: Entering directory `/private/tmp/serialosc-20240114-4751-lp9158/build'
  [ 1/23] Compiling src/common/util.c
  [ 2/23] Compiling src/common/ipc.c
  [ 3/23] Compiling src/common/platform/darwin.c
  [ 4/23] Compiling src/common/platform/posix.c
  [ 5/23] Compiling third-party/confuse/reallocarray.c
  [ 6/23] Compiling third-party/confuse/confuse.c
  [ 7/23] Compiling third-party/confuse/lexer.c
  [ 8/23] Compiling src/serialoscd/uv.c
  [ 9/23] Compiling src/serialosc-detector/iokitlib.c
  ../third-party/confuse/confuse.c:792:10: error: 'fmemopen' is only available on macOS 10.13 or newer [-Werror,-Wunguarded-availability-new]
                                  fp = fmemopen(buf, strlen(buf), "r");
                                       ^~~~~~~~
  /Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/stdio.h:366:7: note: 'fmemopen' has been marked as being introduced in macOS 10.13 here, but the deployment target is macOS 10.5.0
  FILE *fmemopen(void * __restrict __buf, size_t __size, const char * __restrict __mode) __API_AVAILABLE(macos(10.13), ios(11.0), tvos(11.0), watchos(4.0));
        ^
  ../third-party/confuse/confuse.c:792:10: note: enclose 'fmemopen' in a __builtin_available check to silence this warning
                                  fp = fmemopen(buf, strlen(buf), "r");
                                       ^~~~~~~~
  ../third-party/confuse/confuse.c:1829:7: error: 'fmemopen' is only available on macOS 10.13 or newer [-Werror,-Wunguarded-availability-new]
          fp = fmemopen((void *)buf, strlen(buf), "r");
               ^~~~~~~~
  /Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/stdio.h:366:7: note: 'fmemopen' has been marked as being introduced in macOS 10.13 here, but the deployment target is macOS 10.5.0
  FILE *fmemopen(void * __restrict __buf, size_t __size, const char * __restrict __mode) __API_AVAILABLE(macos(10.13), ios(11.0), tvos(11.0), watchos(4.0));
        ^
  ../third-party/confuse/confuse.c:1829:7: note: enclose 'fmemopen' in a __builtin_available check to silence this warning
          fp = fmemopen((void *)buf, strlen(buf), "r");
               ^~~~~~~~
  2 errors generated.
  
  Waf: Leaving directory `/private/tmp/serialosc-20240[114](https://github.com/Homebrew/homebrew-core/actions/runs/7522449788/job/20474502425?pr=159939#step:3:115)-4751-lp9158/build'
  Build failed
```

I'm not well familiar with building serialosc but I added this patch in order for it to build successfully.