### PR TITLE
build: apply -Wno-incompatible-pointer-types flag for both GCC and Clang

### DIFF
--- a/wscript
+++ b/wscript
@@ -286,7 +286,7 @@ def configure(conf):
 		conf.env.append_unique("CFLAGS", ["-std=c17", "-Wall", "-Werror", "-O2"])
 
 
-	if conf.env.CC_NAME == "gcc":
+	if conf.env.CC_NAME in ["gcc", "clang"]:
 		# FIXME: a poor solution perhaps, it will do for now.
 		# would be better to fix all the relevant signatures.
 		conf.env.append_unique("CFLAGS", ["-Wno-incompatible-pointer-types"])


### PR DESCRIPTION
relates to #75