### PR TITLE
Add Systemd Unit for Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ cmake --build .
 
 cmake project is currently configured to build statically linked binaries using bundled libmonome, liblo, libuv and is the suggested way of building serialosc on windows (msys2).
 
+## running at boot
+
+On Linux, a systemd unit will be available as the unpriviledged user that ran the installation. You can enable serialoscd to start at boot by running `systemctl --user enable serialoscd.service` which will start the daemon at each login.
+
+To manually start and stop, this works like any other systemd unit, for example to start manually `systemctl --user start serialoscd.service` will do.
+
 ## documentation
 
 https://monome.org/docs/serialosc

--- a/serialoscd.service
+++ b/serialoscd.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Starts serialoscd at system boot
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/serialoscd
+
+[Install]
+WantedBy=multi-user.target

--- a/wscript
+++ b/wscript
@@ -313,6 +313,13 @@ def build(bld):
 	bld.recurse("third-party")
 	bld.recurse("src")
 
+def install(ctx):
+    # install a systemd unit file
+    if ctx.env.DEST_OS == 'linux':
+        user_home = os.path.expanduser("~")
+        ctx.install_files(os.path.join(user_home, '.config/systemd/user'), 'serialoscd.service')
+        ctx.exec_command('systemctl daemon-reload')
+
 def dist(dst):
 	pats = [".git*", "**/.git*", ".travis.yml", "**/__pycache__"]
 	with open(".gitignore") as gitignore:


### PR DESCRIPTION
Adds a systemd unit, an install script for Linux only and documentation to start serialoscd at boot and login.