### PR TITLE
ignore devices without monome vendor string on linux

### DIFF
--- a/src/serialosc-detector/libudev.c
+++ b/src/serialosc-detector/libudev.c
@@ -69,27 +69,17 @@ test_cdc_driver(struct udev_device *ud) {
 static char
 test_monome_props(struct udev_device *ud)
 {
-	char *vendor, *model;
+	char *vendor;
 	const char *tmp;
 	tmp = udev_device_get_property_value(ud, "ID_VENDOR");
 	if (!tmp) return 0;
-
 	vendor = strdup(tmp);
 
-	tmp = udev_device_get_property_value(ud, "ID_MODEL");
-	if (!tmp) { 
-		free(vendor);
-		return 0;
-	}
-
-	model = strdup(tmp);
-
 	char res = 0;
-	if (vendor != NULL && model != NULL) { 
-		res = (strcmp(vendor, "monome") == 0) && (strcmp(model, "grid") == 0);
+	if (vendor != NULL) {
+		res = (strcmp(vendor, "monome") == 0);
 	}
 
-	free(model);
 	free(vendor);
 	return res;
 }
@@ -128,14 +118,14 @@ has_usb_cdc_parent(struct udev_device *ud) {
 
 static int
 is_device_compatible(struct udev_device *ud) {
+	if (!test_monome_props(ud)) {
+		return 0;
+	}
 	if (has_usb_serial_parent(ud)) { 
 		return 1;
 	} 
 	if (!has_usb_cdc_parent(ud)) {
 		return 0;
-	}
-	if (test_monome_props(ud)) { 
-		return 1;
 	}
 	if (test_monome_serial(ud)) { 
 		return 1;


### PR DESCRIPTION
it seems serialosc attempts to attach to and query (sending serial data) to any serial device connected.

this small change checks the vendor string (for "monome") first.

note: the "model" (product) string query i believe is obsolete/irrelevant.

unfortunately the iokit and windows detection schemes are inscrutable to me, i'm not sure if those platforms can do vendor/product detection. if it's useful for CDC we could shift to PID/VID but older grids use a shared PID/VID (provided by stm) which means it'd still have collisions with some DIY devices without a vendor comparison.

primary use case:

the new iii mode (for grids) uses a toggle-able serial mode, so it can be serialosc-compatible. for the lua-repl mode i want serialosc to ignore the device. by changing the vendor to `iii` serialosc ignores the device appropriately.

of course perhaps there's a better way.